### PR TITLE
Cleansed export ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 * text=auto
 
-/.editorconfig export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.travis.yml export-ignore
-/features export-ignore
-/spec export-ignore
-/tests export-ignore
-/Test export-ignore
+.appveyor.yml export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CHANGELOG.md export-ignore
+LICENSE export-ignore
+phpspec.yml export-ignore
+README.md export-ignore
+spec/ export-ignore


### PR DESCRIPTION
- Added missing export ignores e.g. for AppVeyor also includes `CHANGELOG.md`, `LICENSE` and `README.md`. If these should be kept in release files these can be removed from the ignored files in `.gitattributes`.
- Removed export ignores for non existent artifacts e.g. `tests/` and `features/`.
- Fixed patterns i.e. a prefixed / is not required.

Is `phpspec.yml` required in the release dist? If not it should be prolly renamed to `phpspec.yml.dist`. Otherwise it should be removed from the ignored files in `.gitattributes`.