### PR TITLE
Fix composer phpunit/php-code-coverage requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.0",
         "phpspec/phpspec": "^4.0",
-        "phpunit/php-code-coverage": "~4.0||~5.0"
+        "phpunit/php-code-coverage": "~5.0"
     },
     "require-dev": {
         "bossa/phpspec2-expect": "^3.0"


### PR DESCRIPTION
In commit a5ae5a66340ffd1c7892ae50d226252fb41248f9 a dependency for SebastianBergmann\CodeCoverage\Version was added which is only available since phpunit/php-code-coverage 5.0. This removes 4.0 from the allowed phpunit/php-code-coverage versions.