### PR TITLE
Support for PHP Code Coverage 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.0",
         "phpspec/phpspec": "^4.0",
-        "phpunit/php-code-coverage": "~4.0||~5.0"
+        "phpunit/php-code-coverage": "~4.0||~5.0||~6.0"
     },
     "require-dev": {
         "bossa/phpspec2-expect": "^3.0"


### PR DESCRIPTION
Looks like there's not too much to do to use the newer version. Needed to run the library in Sf4 environment.