### PR TITLE
Added coverage flag to run

### DIFF
--- a/src/Listener/NoCodeCoverageListener.php
+++ b/src/Listener/NoCodeCoverageListener.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LeanPHP\PhpSpec\CodeCoverage\Listener;
+
+use PhpSpec\Console\ConsoleIO;
+use PhpSpec\Event\SuiteEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Danny Lewis
+ */
+class NoCodeCoverageListener implements EventSubscriberInterface
+{
+    private $io;
+
+    public function __construct(ConsoleIO $io)
+    {
+        $this->io = $io;
+    }
+
+    public function showDisabledMessage(SuiteEvent $event)
+    {
+        $this->io->writeln('Code coverage is disabled, enable with "coverage" flag. e.g. bin/phpspec run --coverage');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'beforeSuite'   => array('showDisabledMessage', -10),
+            'afterSuite'    => array('showDisabledMessage', -10),
+        );
+    }
+}


### PR DESCRIPTION
Generating code coverage is slow so I've added flag --coverage to the run command to generate reports if set, if it's not set it informs the user of how to set the flag.  This is inline with the PHPUnit way of enabling coverage reports.