### PR TITLE
Add Code Style guides using PHP CodeSniffer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,5 +77,6 @@ install:
 
 test_script:
   - cd c:\projects\phpspec-code-coverage
-  - phpdbg -qrr vendor\phpspec\phpspec\bin\phpspec run -vvv
+  - bin\phpcs
+  - phpdbg -qrr vendor\phpspec\phpspec\bin\phpspec run --no-code-generation -vvv
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 script:
   - composer validate
   - composer update
+  - bin/phpcs
   - bin/phpspec run --no-code-generation
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
         "phpunit/php-code-coverage": "~6.0"
     },
     "require-dev": {
-        "bossa/phpspec2-expect": "^3.0"
+        "bossa/phpspec2-expect": "^3.0",
+        "escapestudios/symfony2-coding-standard": "^3.1",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "suggest": {
         "ext-xdebug": "Install Xdebug to generate phpspec code coverage if you are not using phpdbg"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!-- leanphp/common-dev phpcs.xml example config -->
+<ruleset name="LeanPHP Coding Standard">
+    <description>LeanPHP Coding Standard</description>
+
+    <!-- directories and files to scan -->
+    <file>src</file>
+
+    <!-- directories and files to exclude -->
+    <exclude-pattern>test</exclude-pattern>
+    <exclude-pattern>tests</exclude-pattern>
+    <exclude-pattern>*Spec.php</exclude-pattern>
+
+    <!-- uncomment for a summary instead of detailed report -->
+    <!--<arg name="report" value="summary"/>-->
+    <arg value="p"/>>
+
+    <!-- Use Symfony2 Coding Standard -->
+    <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony"/>
+</ruleset>

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -1,5 +1,12 @@
 <?php
-
+/**
+ * This file is part of the leanphp/phpspec-code-coverage package
+ *
+ * For the full copyright and license information, please see the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @license MIT
+ */
 namespace LeanPHP\PhpSpec\CodeCoverage;
 
 use LeanPHP\PhpSpec\CodeCoverage\Listener\CodeCoverageListener;
@@ -24,7 +31,7 @@ class CodeCoverageExtension implements \PhpSpec\Extension
     public function load(ServiceContainer $container, array $params = [])
     {
         foreach ($container->getByTag('console.commands') as $command) {
-            if ($command->getName() == 'run') {
+            if ($command->getName() === 'run') {
                 $command->addOption('no-coverage', null, InputOption::VALUE_NONE, 'Skip code coverage generation');
             }
         }
@@ -48,7 +55,7 @@ class CodeCoverageExtension implements \PhpSpec\Extension
             }
 
             if (isset($options['output'])) {
-                if (!is_array($options['output']) && count($options['format']) == 1) {
+                if (!is_array($options['output']) && count($options['format']) === 1) {
                     $format = $options['format'][0];
                     $options['output'] = array($format => $options['output']);
                 }
@@ -100,6 +107,7 @@ class CodeCoverageExtension implements \PhpSpec\Extension
             }
 
             $container->setParam('code_coverage', $options);
+
             return $reports;
         });
 

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -1,5 +1,12 @@
 <?php
-
+/**
+ * This file is part of the leanphp/phpspec-code-coverage package
+ *
+ * For the full copyright and license information, please see the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @license MIT
+ */
 namespace LeanPHP\PhpSpec\CodeCoverage\Listener;
 
 use PhpSpec\Console\ConsoleIO;
@@ -20,6 +27,12 @@ class CodeCoverageListener implements EventSubscriberInterface
     private $options;
     private $enabled;
 
+    /**
+     * @param ConsoleIO    $io
+     * @param CodeCoverage $coverage
+     * @param []           $reports
+     * @param boolean      $skipCoverage
+     */
     public function __construct(ConsoleIO $io, CodeCoverage $coverage, array $reports, $skipCoverage = false)
     {
         $this->io = $io;
@@ -40,6 +53,8 @@ class CodeCoverageListener implements EventSubscriberInterface
     /**
      * Note: We use array_map() instead of array_walk() because the latter expects
      * the callback to take the value as the first and the index as the seconds parameter.
+     *
+     * @param SuiteEvent $event
      */
     public function beforeSuite(SuiteEvent $event)
     {
@@ -67,6 +82,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param ExampleEvent $event
+     */
     public function beforeExample(ExampleEvent $event)
     {
         if (!$this->enabled) {
@@ -83,6 +101,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         $this->coverage->start($name);
     }
 
+    /**
+     * @param ExampleEvent $event
+     */
     public function afterExample(ExampleEvent $event)
     {
         if (!$this->enabled) {
@@ -92,6 +113,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         $this->coverage->stop();
     }
 
+    /**
+     * @param SuiteEvent $event
+     */
     public function afterSuite(SuiteEvent $event)
     {
         if (!$this->enabled) {
@@ -120,6 +144,9 @@ class CodeCoverageListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param [] $options
+     */
     public function setOptions(array $options)
     {
         $this->options = $options + $this->options;


### PR DESCRIPTION
- Fixes #21 
- Add `squizlabs/php_codesniffer` and `escapestudios/symfony2-coding-standard` to `require-dev`
- Add `phpcs.xml` config for PHP CodeSniffer
- Add `bin/phpcs` to appveyor and travis builds
- Update classes to match the defined PHP coding standard (add PHPDoc blocks + fix few minor coding issues)