### PR TITLE
Fix missing check for 'no-coverage' option

### DIFF
--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -118,7 +118,7 @@ class CodeCoverageExtension implements Extension
 
             $skipCoverage = false;
             $input = $container->get('console.input');
-            if ($input->getOption('no-coverage')) {
+            if (!$input->hasOption('no-coverage') || $input->getOption('no-coverage')) {
                 $skipCoverage = true;
             }
 


### PR DESCRIPTION
Executing 'bin/phpspec describe ...' after installing the lib gives me the following error : 
> "The "no-coverage" option does not exist.

It might be an edge case, or config related. Unfortunately I didn't have time to investigate further into the codebase, but adding this check should prevent the error without side effect.

Let me know if you see any harm.