### PR TITLE
Fix for `--no-coverage` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated PHP requirement from `^7.0` to `^7.1`
 - Updated `phpspec/phpspec` dependency from `~4.0` to `^4.2`
 
+## [4.1.2] - 2018-03-21
+
+- Fix `--no-coverage` option introducing errors when running non `run` commands.
+- `--no-coverage` option is now available to all phpspec commands (not only
+  `run`). (#30)
+
 ## [4.1.1] - 2018-03-19
 
 - Added `--no-coverage` option which can skip code coverage generation during
@@ -92,6 +98,7 @@ as [leanphp/phpspec-code-coverage][0].
   reports (`blaclist_files` option).
 
 [4.2.0]: https://github.com/leanphp/phpspec-code-coverage/releases/tag/v4.2.0
+[4.1.2]: https://github.com/leanphp/phpspec-code-coverage/releases/tag/v4.1.2
 [4.1.1]: https://github.com/leanphp/phpspec-code-coverage/releases/tag/v4.1.1
 [4.1.0]: https://github.com/leanphp/phpspec-code-coverage/releases/tag/v4.1.0
 [4.0.0]: https://github.com/leanphp/phpspec-code-coverage/releases/tag/v4.0.0

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -35,9 +35,7 @@ class CodeCoverageExtension implements Extension
     public function load(ServiceContainer $container, array $params = [])
     {
         foreach ($container->getByTag('console.commands') as $command) {
-            if ($command->getName() === 'run') {
-                $command->addOption('no-coverage', null, InputOption::VALUE_NONE, 'Skip code coverage generation');
-            }
+            $command->addOption('no-coverage', null, InputOption::VALUE_NONE, 'Skip code coverage generation');
         }
 
         $container->define('code_coverage.filter', function () {
@@ -118,7 +116,7 @@ class CodeCoverageExtension implements Extension
 
             $skipCoverage = false;
             $input = $container->get('console.input');
-            if (!$input->hasOption('no-coverage') || $input->getOption('no-coverage')) {
+            if ($input->hasOption('no-coverage') && $input->getOption('no-coverage')) {
                 $skipCoverage = true;
             }
 

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -118,7 +118,7 @@ class CodeCoverageExtension implements Extension
 
             $skipCoverage = false;
             $input = $container->get('console.input');
-            if ($input->getOption('no-coverage')) {
+            if (!$input->hasOption('no-coverage') || $input->getOption('no-coverage')) {
                 $skipCoverage = true;
             }
 


### PR DESCRIPTION
- Fix for `--no-coverage` introducing errors when running any other command that `phpspec run`
- Make `--no-coverage` argument available to all phpspec commands.

Fixes #30 
Has commits from PR #29 