### PR TITLE
Allow to use code coverage with PHPSpec 5.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
     "require": {
         "php": "^7.1",
-        "phpspec/phpspec": "^4.2",
-        "phpunit/php-code-coverage": "^5.0||^6.0"
+        "phpspec/phpspec": "^4.2||^5.0",
+        "phpunit/php-code-coverage": "^5.0||^6.0||^7.0"
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.1",

--- a/spec/CodeCoverageExtensionSpec.php
+++ b/spec/CodeCoverageExtensionSpec.php
@@ -5,6 +5,7 @@ namespace spec\LeanPHP\PhpSpec\CodeCoverage;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\ServiceContainer\IndexedServiceContainer;
 use Prophecy\Argument;
+use LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension;
 
 /**
  * @author Henrik Bjornskov
@@ -13,7 +14,7 @@ class CodeCoverageExtensionSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension');
+        $this->shouldHaveType(CodeCoverageExtension::class);
     }
 
     function it_should_use_html_format_by_default()
@@ -50,7 +51,5 @@ class CodeCoverageExtensionSpec extends ObjectBehavior
         if ($options['output'] !== ['foo' => 'test']) {
             throw new Exception("Default format is not singular output");
         }
-
-
     }
 }

--- a/spec/Exception/NoCoverageDriverAvailableExceptionSpec.php
+++ b/spec/Exception/NoCoverageDriverAvailableExceptionSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace spec\LeanPHP\PhpSpec\CodeCoverage\Exception;
+
+use PhpSpec\ObjectBehavior;
+use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
+
+/**
+ * @author Stéphane Hulard
+ */
+class NoCoverageDriverAvailableExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldBeAnInstanceOf(\RuntimeException::class);
+        $this->shouldHaveType(NoCoverageDriverAvailableException::class);
+    }
+}

--- a/src/CodeCoverageExtension.php
+++ b/src/CodeCoverageExtension.php
@@ -20,6 +20,7 @@ use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report;
 use SebastianBergmann\CodeCoverage\Version;
 use Symfony\Component\Console\Input\InputOption;
+use LeanPHP\PhpSpec\CodeCoverage\Exception\NoCoverageDriverAvailableException;
 
 /**
  * Injects Code Coverage Event Subscriber into the EventDispatcher.
@@ -43,7 +44,17 @@ class CodeCoverageExtension implements Extension
         });
 
         $container->define('code_coverage', function ($container) {
-            return new CodeCoverage(null, $container->get('code_coverage.filter'));
+            try {
+                $coverage = new CodeCoverage(null, $container->get('code_coverage.filter'));
+            } catch (\RuntimeException $error) {
+                throw new NoCoverageDriverAvailableException(
+                    "There is no available coverage driver to be used.",
+                    0,
+                    $error
+                );
+            }
+
+            return $coverage;
         });
 
         $container->define('code_coverage.options', function ($container) use ($params) {

--- a/src/Exception/NoCoverageDriverAvailableException.php
+++ b/src/Exception/NoCoverageDriverAvailableException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the leanphp/phpspec-code-coverage package
+ *
+ * @author shulard <s.hulard@chstudio.fr>
+ *
+ * @license MIT
+ *
+ * For the full copyright and license information, please see the LICENSE file
+ * that was distributed with this source code.
+ *
+ */
+namespace LeanPHP\PhpSpec\CodeCoverage\Exception;
+
+use \RuntimeException;
+
+/**
+ * When PHPUnit/CodeCoverage trigger an exception which says that's no driver
+ * can be found, we catch it to decorate with our own.
+ *
+ * @author Stéphane Hulard
+ */
+class NoCoverageDriverAvailableException extends RuntimeException
+{
+}

--- a/src/Listener/CodeCoverageListener.php
+++ b/src/Listener/CodeCoverageListener.php
@@ -28,7 +28,6 @@ class CodeCoverageListener implements EventSubscriberInterface
     private $reports;
     private $io;
     private $options;
-    private $enabled;
     private $skipCoverage;
 
     /**
@@ -51,7 +50,6 @@ class CodeCoverageListener implements EventSubscriberInterface
             'format'    => ['html'],
         ];
 
-        $this->enabled = extension_loaded('xdebug') || (PHP_SAPI === 'phpdbg');
         $this->skipCoverage = $skipCoverage;
     }
 
@@ -63,7 +61,7 @@ class CodeCoverageListener implements EventSubscriberInterface
      */
     public function beforeSuite(SuiteEvent $event) : void
     {
-        if (!$this->enabled || $this->skipCoverage) {
+        if ($this->skipCoverage) {
             return;
         }
 
@@ -92,7 +90,7 @@ class CodeCoverageListener implements EventSubscriberInterface
      */
     public function beforeExample(ExampleEvent $event): void
     {
-        if (!$this->enabled || $this->skipCoverage) {
+        if ($this->skipCoverage) {
             return;
         }
 
@@ -111,7 +109,7 @@ class CodeCoverageListener implements EventSubscriberInterface
      */
     public function afterExample(ExampleEvent $event): void
     {
-        if (!$this->enabled || $this->skipCoverage) {
+        if ($this->skipCoverage) {
             return;
         }
 
@@ -123,13 +121,9 @@ class CodeCoverageListener implements EventSubscriberInterface
      */
     public function afterSuite(SuiteEvent $event): void
     {
-        if (!$this->enabled || $this->skipCoverage) {
+        if ($this->skipCoverage) {
             if ($this->io && $this->io->isVerbose()) {
-                if (!$this->enabled) {
-                    $this->io->writeln('No code coverage will be generated as neither Xdebug nor phpdbg was detected.');
-                } elseif ($this->skipCoverage) {
-                    $this->io->writeln('Skipping code coverage generation');
-                }
+                $this->io->writeln('Skipping code coverage generation');
             }
 
             return;


### PR DESCRIPTION
Hello,

I've created this little PR to upgrade the dependencies and allow to use this awesome CodeCoverage wrapper on latest library releases. 

This also allow to use the new PCov coverage driver which is lighter : https://github.com/krakjoe/pcov